### PR TITLE
💎 Support PSR-11 (container)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     },
     "require": {
         "php": ">=8.3",
-        "psr/cache": "^1.0|^2.0|^3.0"
+        "psr/cache": "^1.0|^2.0|^3.0",
+        "psr/container": "^1.0|^2.0"
     },
     "require-dev": {
         "rector/rector": "^2.0",

--- a/src/HookLoader.php
+++ b/src/HookLoader.php
@@ -10,21 +10,33 @@ use Dbout\WpHook\Enums\ActionType;
 use Dbout\WpHook\Exceptions\HookException;
 use Dbout\WpHook\FileLocators\FileLocator;
 use Dbout\WpHook\Helpers\SortActions;
+use Dbout\WpHook\Instantiators\ClassInstantiatorInterface;
+use Dbout\WpHook\Instantiators\ContainerClassInstantiator;
 use Dbout\WpHook\Loaders\AttributeDirectoryLoader;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
 
 class HookLoader
 {
     private const string CACHE_KEY = '_app_wp_autoloader_hooks';
 
+    protected ?ClassInstantiatorInterface $instantiator = null;
+
     /**
-     * @param string|array<string> $directory
+     * @param string|string[] $directory
      * @param CacheItemPoolInterface|null $cache
+     * @param ContainerInterface|ClassInstantiatorInterface|null $container PSR-11 container or custom instantiator for dependency injection
      */
     public function __construct(
         protected string|array $directory,
         public ?CacheItemPoolInterface $cache = null,
+        ContainerInterface|ClassInstantiatorInterface|null $container = null,
     ) {
+        if ($container instanceof ClassInstantiatorInterface) {
+            $this->instantiator = $container;
+        } elseif ($container instanceof ContainerInterface) {
+            $this->instantiator = new ContainerClassInstantiator($container);
+        }
     }
 
     /**
@@ -66,7 +78,8 @@ class HookLoader
         $hooks = [];
         foreach ($directories as $directory) {
             $loader = new AttributeDirectoryLoader(
-                new FileLocator([$directory])
+                new FileLocator([$directory]),
+                $this->instantiator,
             );
 
             $hooks = array_merge($hooks, $loader->load($directory));

--- a/src/Instantiators/ClassInstantiatorInterface.php
+++ b/src/Instantiators/ClassInstantiatorInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpHook\Instantiators;
+
+/**
+ * Interface for class instantiation strategies.
+ *
+ * Allows different strategies for instantiating hook classes,
+ * such as using reflection (default) or a dependency injection container.
+ */
+interface ClassInstantiatorInterface
+{
+    /**
+     * Instantiates a class by its fully qualified class name.
+     *
+     * @template T of object
+     * @param class-string<T> $className The fully qualified class name to instantiate
+     * @return T The instantiated object
+     */
+    public function instantiate(string $className): object;
+}

--- a/src/Instantiators/ContainerClassInstantiator.php
+++ b/src/Instantiators/ContainerClassInstantiator.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpHook\Instantiators;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Class instantiator using a PSR-11 container.
+ *
+ * Allows hook classes to be instantiated through a dependency injection container,
+ * enabling constructor injection and proper dependency management.
+ */
+class ContainerClassInstantiator implements ClassInstantiatorInterface
+{
+    /**
+     * @param ContainerInterface $container The PSR-11 container to use for instantiation
+     */
+    public function __construct(
+        protected ContainerInterface $container,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function instantiate(string $className): object
+    {
+        return $this->container->get($className);
+    }
+}

--- a/src/Instantiators/ReflectionClassInstantiator.php
+++ b/src/Instantiators/ReflectionClassInstantiator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpHook\Instantiators;
+
+/**
+ * Default class instantiator using reflection.
+ *
+ * Instantiates classes without calling their constructor,
+ * which is the original behavior of the package.
+ */
+class ReflectionClassInstantiator implements ClassInstantiatorInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function instantiate(string $className): object
+    {
+        $reflectionClass = new \ReflectionClass($className);
+
+        return $reflectionClass->newInstanceWithoutConstructor();
+    }
+}

--- a/src/Loaders/AttributeClassLoader.php
+++ b/src/Loaders/AttributeClassLoader.php
@@ -11,9 +11,19 @@ use Dbout\WpHook\Attributes\Action as ActionAttribute;
 use Dbout\WpHook\Attributes\Filter as FilterAttribute;
 use Dbout\WpHook\Attributes\FilterInterface;
 use Dbout\WpHook\Exceptions\HookException;
+use Dbout\WpHook\Instantiators\ClassInstantiatorInterface;
+use Dbout\WpHook\Instantiators\ReflectionClassInstantiator;
 
 class AttributeClassLoader implements InterfaceLoader
 {
+    /**
+     * @param ClassInstantiatorInterface $instantiator
+     */
+    public function __construct(
+        protected ClassInstantiatorInterface $instantiator = new ReflectionClassInstantiator(),
+    ) {
+    }
+
     /**
      * @inheritDoc
      * @return Action[]
@@ -141,7 +151,7 @@ class AttributeClassLoader implements InterfaceLoader
             name: $filter->getName(),
             priority: $filter->getPriority(),
             acceptedArgs: $filter->getAcceptedArgs(),
-            classInstance: $class->newInstanceWithoutConstructor(),
+            classInstance: $this->instantiator->instantiate($class->getName()),
             methodName: $fncName,
             dependencies: $dependencies,
             actionType: $filter->getActionType(),

--- a/src/Loaders/AttributeDirectoryLoader.php
+++ b/src/Loaders/AttributeDirectoryLoader.php
@@ -8,20 +8,28 @@ namespace Dbout\WpHook\Loaders;
 
 use Dbout\WpHook\Action;
 use Dbout\WpHook\FileLocators\FileLocatorInterface;
+use Dbout\WpHook\Instantiators\ClassInstantiatorInterface;
+use Dbout\WpHook\Instantiators\ReflectionClassInstantiator;
 
 class AttributeDirectoryLoader
 {
+    protected AttributeClassLoader $loader;
+
     /**
      * @param FileLocatorInterface $fileLocator
-     * @param AttributeClassLoader $loader
+     * @param ClassInstantiatorInterface|null $instantiator
      */
     public function __construct(
         protected FileLocatorInterface $fileLocator,
-        protected AttributeClassLoader $loader = new AttributeClassLoader(),
+        ?ClassInstantiatorInterface $instantiator = null,
     ) {
         if (!\function_exists('token_get_all')) {
             throw new \LogicException('The Tokenizer extension is required for the routing attribute loader.');
         }
+
+        $this->loader = new AttributeClassLoader(
+            $instantiator ?? new ReflectionClassInstantiator()
+        );
     }
 
     /**

--- a/tests/Unit/Instantiators/ContainerClassInstantiatorTest.php
+++ b/tests/Unit/Instantiators/ContainerClassInstantiatorTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpHook\Tests\Unit\Instantiators;
+
+use Dbout\WpHook\Instantiators\ContainerClassInstantiator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+#[CoversClass(ContainerClassInstantiator::class)]
+class ContainerClassInstantiatorTest extends TestCase
+{
+    public function testInstantiateFromContainer(): void
+    {
+        $expectedInstance = new \stdClass();
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(\stdClass::class)
+            ->willReturn($expectedInstance);
+
+        $instantiator = new ContainerClassInstantiator($container);
+        $result = $instantiator->instantiate(\stdClass::class);
+
+        $this->assertSame($expectedInstance, $result);
+    }
+
+    public function testInstantiateWithDependencies(): void
+    {
+        $dependency = new ServiceDependency();
+        $service = new ServiceWithDependency($dependency);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(ServiceWithDependency::class)
+            ->willReturn($service);
+
+        $instantiator = new ContainerClassInstantiator($container);
+        $result = $instantiator->instantiate(ServiceWithDependency::class);
+
+        $this->assertInstanceOf(ServiceWithDependency::class, $result);
+        $this->assertSame($dependency, $result->getDependency());
+    }
+
+    public function testInstantiateThrowsWhenServiceNotFound(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->willThrowException(new class () extends \Exception implements NotFoundExceptionInterface {});
+
+        $instantiator = new ContainerClassInstantiator($container);
+
+        $this->expectException(NotFoundExceptionInterface::class);
+        $instantiator->instantiate('NonExistentService');
+    }
+}
+
+class ServiceDependency
+{
+}
+
+class ServiceWithDependency
+{
+    public function __construct(
+        private ServiceDependency $dependency,
+    ) {
+    }
+
+    public function getDependency(): ServiceDependency
+    {
+        return $this->dependency;
+    }
+}

--- a/tests/Unit/Instantiators/ReflectionClassInstantiatorTest.php
+++ b/tests/Unit/Instantiators/ReflectionClassInstantiatorTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright (c) Dimitri BOUTEILLE (https://github.com/dimitriBouteille)
+ * See LICENSE.txt for license details.
+ */
+
+namespace Dbout\WpHook\Tests\Unit\Instantiators;
+
+use Dbout\WpHook\Instantiators\ReflectionClassInstantiator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ReflectionClassInstantiator::class)]
+class ReflectionClassInstantiatorTest extends TestCase
+{
+    public function testInstantiateWithoutConstructor(): void
+    {
+        $instantiator = new ReflectionClassInstantiator();
+        $instance = $instantiator->instantiate(ClassWithoutConstructor::class);
+
+        $this->assertInstanceOf(ClassWithoutConstructor::class, $instance);
+    }
+
+    public function testInstantiateBypassesConstructor(): void
+    {
+        $instantiator = new ReflectionClassInstantiator();
+        $instance = $instantiator->instantiate(ClassWithConstructor::class);
+
+        $this->assertInstanceOf(ClassWithConstructor::class, $instance);
+        $this->assertFalse($instance->wasConstructorCalled());
+    }
+
+    public function testInstantiateThrowsExceptionForNonExistentClass(): void
+    {
+        $instantiator = new ReflectionClassInstantiator();
+
+        $this->expectException(\ReflectionException::class);
+        $instantiator->instantiate('NonExistentClass');
+    }
+}
+
+class ClassWithoutConstructor
+{
+}
+
+class ClassWithConstructor
+{
+    private bool $constructorCalled = false;
+
+    public function __construct()
+    {
+        $this->constructorCalled = true;
+    }
+
+    public function wasConstructorCalled(): bool
+    {
+        return $this->constructorCalled;
+    }
+}


### PR DESCRIPTION
This PR introduces support for PSR-11 dependency injection containers, allowing hook classes to be instantiated with their constructor dependencies properly resolved.

```php
// With PSR-11 container (e.g., PHP-DI, Symfony DI, Laravel Container)
$loader = new HookLoader(
    directory: get_template_directory() . '/hooks',
    cache: null,
    container: $container, // PSR-11 ContainerInterface
);

// With custom instantiator
$loader = new HookLoader(
    directory: get_template_directory() . '/hooks',
    cache: null,
    container: new MyCustomInstantiator(),
);
```

  - New `ClassInstantiatorInterface`: Abstraction for class instantiation strategies
  - New `ReflectionClassInstantiator`: Default behavior (instantiates without constructor, backward compatible)
  - New `ContainerClassInstantiator`: Uses PSR-11 container for dependency injection
  - Updated `HookLoader`: Accepts optional `ContainerInterface` or `ClassInstantiatorInterface` as third parameter
  - Updated `AttributeClassLoader` and `AttributeDirectoryLoader`**: Propagate instantiator through the loading chain